### PR TITLE
Make CW text box visible with overlay scrollbars

### DIFF
--- a/src/gui_netkeyer.c
+++ b/src/gui_netkeyer.c
@@ -490,6 +490,7 @@ void on_keyer_activate (GtkAction *action, gpointer user_data)
 
 	keyertext = gtk_text_view_new ();
 	gtk_container_add (GTK_CONTAINER (scrolledkeyerwindow), keyertext);
+       gtk_widget_set_size_request (scrolledkeyerwindow, -1, 100);
 	gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW(keyertext), GTK_WRAP_CHAR);
 
 	gtk_entry_set_max_length (GTK_ENTRY (f1entry), 80);


### PR DESCRIPTION
Recent versions of Ubuntu use overlay scrollbars,
which mean that GtkScrolledWindows no longer set a
minimum height that provides enough room for a
legacy scrollbar

Alternative is to use LIBOVERLAY_SCROLLBAR=0